### PR TITLE
[keep] Refactoring to keep original methods and sync methods

### DIFF
--- a/spec/file_async_spec.js
+++ b/spec/file_async_spec.js
@@ -4,6 +4,17 @@ import fsAsync from '../src/file-async';
 
 describe('fsAsync:', function() {
 
+  it("should keep support sync methods", function() {
+    h.expect(fsAsync.existsSync(__filename)).to.ok;
+  });
+
+  it("should keep support callback methods", function(done) {
+    fsAsync.readFileCallback(__filename, function(err, file_content) {
+      h.expect(file_content.toString()).not.been.undefined;
+      done();
+    });
+  });
+
   it('should read a file', function () {
     return fsAsync.readFile(__filename).then(function(file_content) {
       return h.expect(file_content.toString()).not.been.undefined;

--- a/src/file-async.js
+++ b/src/file-async.js
@@ -1,91 +1,35 @@
 import BB from 'bluebird';
-var fs = require('fs-extra');
+var extra = require('fs-extra');
 
-BB.promisifyAll(fs);
-
-var FileAsync = {
-
-  /**
-   * stat :: fs.stat
-   * @param  {string} full_path     file's fullpath to get stat
-   * @return {object} fsStat        stat functions: isFile, isDirectory, isBlockDevice, isCharacterDevice, isSymbolicLink, isFIFO, isSocket
-   *
-   * https://github.com/petkaantonov/bluebird/issues/5#issuecomment-25747355
-  */
+var final = {
+  existsCallback: extra.exists.bind(extra),
   exists: function (full_path) {
-    return new BB.Promise(function (resolve, reject) {
-      return fs.statAsync(full_path).then(function () {
-        return resolve(true);
-      })
-      .catch(function (err) {
-        if (err.code === 'ENOENT') {
-          return resolve(false);
-        }
-        return reject(err);
-      });
+    return new BB.Promise((resolve) => {
+      this.existsCallback(full_path, resolve);
     });
   },
-
-  // other fs & fs-extra methods
-  appendFile:        (...args) => { return fs.appendFileAsync(...args); },
-  chmod:             (...args) => { return fs.chmodAsync(...args); },
-  chown:             (...args) => { return fs.chownAsync(...args); },
-  close:             (...args) => { return fs.closeAsync(...args); },
-  copy:              (...args) => { return fs.copyAsync(...args); },
-  createFile:        (...args) => { return fs.createFileAsync(...args); },
-  createReadStream:  (...args) => { return fs.createReadStreamAsync(...args); },
-  createWriteStream: (...args) => { return fs.createWriteStreamAsync(...args); },
-  delete:            (...args) => { return fs.deleteAsync(...args); },
-  ensureDir:         (...args) => { return fs.ensureDirAsync(...args); },
-  ensureFile:        (...args) => { return fs.ensureFileAsync(...args); },
-  fchmod:            (...args) => { return fs.fchmodAsync(...args); },
-  fchown:            (...args) => { return fs.fchownAsync(...args); },
-  fdatasync:         (...args) => { return fs.fdatasyncAsync(...args); },
-  fstat:             (...args) => { return fs.fstatAsync(...args); },
-  fsync:             (...args) => { return fs.fsyncAsync(...args); },
-  ftruncate:         (...args) => { return fs.ftruncateAsync(...args); },
-  futimes:           (...args) => { return fs.futimesAsync(...args); },
-  lchmod:            (...args) => { return fs.lchmodAsync(...args); },
-  lchown:            (...args) => { return fs.lchownAsync(...args); },
-  link:              (...args) => { return fs.linkAsync(...args); },
-  lstat:             (...args) => { return fs.lstatAsync(...args); },
-  lutimes:           (...args) => { return fs.lutimesAsync(...args); },
-  mkdir:             (...args) => { return fs.mkdirAsync(...args); },
-  mkdirp:            (...args) => { return fs.mkdirpAsync(...args); },
-  mkdirs:            (...args) => { return fs.mkdirsAsync(...args); },
-  move:              (...args) => { return fs.moveAsync(...args); },
-  open:              (...args) => { return fs.openAsync(...args); },
-  outputFile:        (...args) => { return fs.outputFileAsync(...args); },
-  outputJson:        (...args) => { return fs.outputJsonAsync(...args); },
-  outputJSON:        (...args) => { return fs.outputJSONAsync(...args); },
-  read:              (...args) => { return fs.readAsync(...args); },
-  readdir:           (...args) => { return fs.readdirAsync(...args); },
-  readFile:          (...args) => { return fs.readFileAsync(...args); },
-  readJson:          (...args) => { return fs.readJsonAsync(...args); },
-  readJSON:          (...args) => { return fs.readJSONAsync(...args); },
-  readJsonFile:      (...args) => { return fs.readJsonFileAsync(...args); },
-  readJSONFile:      (...args) => { return fs.readJSONFileAsync(...args); },
-  readlink:          (...args) => { return fs.readlinkAsync(...args); },
-  realpath:          (...args) => { return fs.realpathAsync(...args); },
-  remove:            (...args) => { return fs.removeAsync(...args); },
-  rename:            (...args) => { return fs.renameAsync(...args); },
-  rmdir:             (...args) => { return fs.rmdirAsync(...args); },
-  stat:              (...args) => { return fs.statAsync(...args); },
-  symlink:           (...args) => { return fs.symlinkAsync(...args); },
-  touch:             (...args) => { return fs.touchAsync(...args); },
-  truncate:          (...args) => { return fs.truncateAsync(...args); },
-  unlink:            (...args) => { return fs.unlinkAsync(...args); },
-  unwatchFile:       (...args) => { return fs.unwatchFileAsync(...args); },
-  utimes:            (...args) => { return fs.utimesAsync(...args); },
-  watch:             (...args) => { return fs.watchAsync(...args); },
-  watchFile:         (...args) => { return fs.watchFileAsync(...args); },
-  write:             (...args) => { return fs.writeAsync(...args); },
-  writeFile:         (...args) => { return fs.writeFileAsync(...args); },
-  writeJson:         (...args) => { return fs.writeJsonAsync(...args); },
-  writeJSON:         (...args) => { return fs.writeJSONAsync(...args); },
-  writeJsonFile:     (...args) => { return fs.writeJsonFileAsync(...args); },
-  writeJSONFile:     (...args) => { return fs.writeJSONFileAsync(...args); },
-
 };
 
-module.exports = FileAsync;
+var async_methods = [];
+var async_object  = BB.promisifyAll(extra, {
+  // Skip .*Sync methods
+  filter: (name, func, target, passesDefaultFilter) => {
+    if (passesDefaultFilter && target === extra && !final[name]) {
+      if (name.match(/Sync$/)) {
+        final[name] = extra[name].bind(extra);
+      } else {
+        async_methods.push(name);
+        return true;
+      }
+    }
+    return false;
+  },
+});
+
+// Rename .*Async methods
+async_methods.forEach((method) => {
+  final[method + "Callback"] = extra[method];
+  final[method] = async_object[method + "Async"].bind(async_object);
+});
+
+module.exports = final;


### PR DESCRIPTION
This change modifies the way asynchronous methods for `fs-extra` are transformed into methods that return promises having the following advantages over the current approach:
- Automatic support for future methods that can be added to the `fs-extra`
- Keeps sync methods
- Keeps the original async methods by adding the suffix "Callback"
